### PR TITLE
setupext.pip: Add absolute_import.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+* Next Release
+
+  - Add ``from future import absolute_import`` to make the extension
+    safe on older Python versions.
+
 * 1.0.3 (30-Jul-2014)
   
   - Fix ``setup.py test``.  It was hanging forever unless you passed it

--- a/setupext/pip.py
+++ b/setupext/pip.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 
 import pkg_resources


### PR DESCRIPTION
The `ImportError` guard around the `pip.commands.install` import was hiding a subtle problem.  `from pip.commands` could refer to the `setupext.pip` module when it is installed.
