### PR TITLE
Travis CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 - '3.3'
 - '3.4'
 install:
-- pip install -r dev-requirements.txt
+- pip install pytest-cov
 script:
 - py.test
 branches:


### PR DESCRIPTION
Builds were taking a lot more time than they should because of the sphinx installation.  There is no need for this on the Travis CI side of things so I'll make things a little less DRY and pick up some build speed.
